### PR TITLE
Resolve unassigned variable error

### DIFF
--- a/Scripts/Editor/Updater/HoyoToonUpdater.cs
+++ b/Scripts/Editor/Updater/HoyoToonUpdater.cs
@@ -71,9 +71,11 @@ namespace HoyoToon
             {
                 yield return webRequest.SendWebRequest();
 
+                // Fix for unassigned variable (CS0165)
+                object version = null;
                 string remoteVersion = webRequest.result == UnityWebRequest.Result.ConnectionError || webRequest.result == UnityWebRequest.Result.ProtocolError
                     ? null
-                    : JsonConvert.DeserializeObject<Dictionary<string, object>>(webRequest.downloadHandler.text)?.TryGetValue("version", out var version) == true ? version.ToString() : null;
+                    : JsonConvert.DeserializeObject<Dictionary<string, object>>(webRequest.downloadHandler.text)?.TryGetValue("version", out version) == true ? version.ToString() : null;
 
                 if (remoteVersion == null)
                 {


### PR DESCRIPTION
Fixes the **CS0165 unassigned variable** error in Unity 2021, so now you can use this shader in the mentioned version of Unity

_Tested on Unity 2021 and Unity 2022_